### PR TITLE
feat: add idle mode feature to Gauge component

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ![NPM Downloads](https://img.shields.io/npm/dm/vue-circular-gauge)
 ![npm bundle size](https://img.shields.io/bundlephobia/min/vue-circular-gauge)
 
-
 # Vue Gauge Component
 
 A customizable circular gauge/progress component for Vue.js. This component is a Vue port of the [Gauge component by Onur Şuyalçınkaya](https://github.com/suyalcinkaya/gauge).
@@ -21,6 +20,7 @@ A customizable circular gauge/progress component for Vue.js. This component is a
 - Ascending or descending variants
 - Display value inside gauge
 - Fully reactive
+- Idle mode
 
 ## Installation
 
@@ -73,6 +73,7 @@ import { Gauge } from 'vue-circular-gauge'
 | showAnimation | Boolean               | false       | Whether to animate the gauge when it first renders                |
 | primary       | String, Array, Object | null        | Primary color or color scale for the gauge                        |
 | secondary     | String, Array, Object | null        | Secondary color or color scale for the gauge                      |
+| idleMode      | Boolean               | false       | Whether to show the idle mode icon                                |
 
 ## Default Color Scale
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tailwindcss": "^4.1.7",
     "tw-animate-css": "^1.3.0",
     "vue": "^3.5.13",
-    "vue-circular-gauge": "^1.3.0",
+    "vue-circular-gauge": "2.0.1",
     "vue-router": "^4.5.0",
     "vue-sonner": "^1.3.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^3.5.13
         version: 3.5.14(typescript@5.8.3)
       vue-circular-gauge:
-        specifier: ^1.3.0
-        version: 1.3.0(vue@3.5.14(typescript@5.8.3))
+        specifier: 2.0.1
+        version: 2.0.1(vue@3.5.14(typescript@5.8.3))
       vue-router:
         specifier: ^4.5.0
         version: 4.5.1(vue@3.5.14(typescript@5.8.3))
@@ -2726,8 +2726,8 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
-  vue-circular-gauge@1.3.0:
-    resolution: {integrity: sha512-uahkSj5Q46LoGlYDN01yRUIpH3y9o95f4TI58kgvTSMeexSXxA3yBKI6FckgQgr8r/zzTGlhBJP5V5Zd4Ba6UA==}
+  vue-circular-gauge@2.0.1:
+    resolution: {integrity: sha512-e5sQRiw58/1h85135uMQ16X0+KARH6aSGSmbCxmHnQtH6eFbilKAGesJIiy4+stxW8rXXkFLFPlcTYqx6ok0JQ==}
     peerDependencies:
       vue: ^3.3.0
 
@@ -5393,7 +5393,7 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-circular-gauge@1.3.0(vue@3.5.14(typescript@5.8.3)):
+  vue-circular-gauge@2.0.1(vue@3.5.14(typescript@5.8.3)):
     dependencies:
       clsx: 2.1.1
       tailwind-merge: 2.6.0

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -91,7 +91,7 @@ function openPlayground() {
       <div class="grid grid-rows-[1fr_auto] gap-4">
         <div class="flex flex-col gap-2">
           <h1 class="text-foreground text-2xl font-bold">Gauge</h1>
-          <p>A simple and customizable circular gauge component for Vue 3.</p>
+          <p class="text-balance">A simple and customizable circular gauge component for Vue 3.</p>
         </div>
         <div class="flex items-center gap-2">
           <code

--- a/src/components/Playground.vue
+++ b/src/components/Playground.vue
@@ -40,6 +40,7 @@ const playgroundConfig = ref({
   secondary: '#e2e8f0',
   showValue: true,
   showAnimation: true,
+  idleMode: false,
 })
 
 // Use the animation composable
@@ -106,6 +107,7 @@ function copyConfig() {
             :secondary="playgroundConfig.secondary"
             :show-value="playgroundConfig.showValue"
             :show-animation="playgroundConfig.showAnimation"
+            :idle-mode="playgroundConfig.idleMode"
           />
         </CardContent>
         <CardFooter class="w-full">
@@ -134,6 +136,12 @@ function copyConfig() {
               <Checkbox id="showAnimation" v-model="playgroundConfig.showAnimation" />
               <div class="grid gap-1.5 leading-none">
                 <Label for="showAnimation"> Show Animation </Label>
+              </div>
+            </div>
+            <div class="items-top flex gap-x-2">
+              <Checkbox id="idleMode" v-model="playgroundConfig.idleMode" />
+              <div class="grid gap-1.5 leading-none">
+                <Label for="idleMode"> Idle Mode </Label>
               </div>
             </div>
           </div>

--- a/src/views/GaugeDemo.vue
+++ b/src/views/GaugeDemo.vue
@@ -3,10 +3,12 @@ import { ref } from 'vue'
 import { Button } from '@/components/ui/button'
 import { Card, CardTitle, CardContent, CardDescription } from '@/components/ui/card'
 import Playground from '@/components/Playground.vue'
+import { Checkbox } from '@/components/ui/checkbox'
 
 const value = ref(50)
 const animating = ref(true)
 const animationValue = ref(72)
+const idleMode = ref(false)
 
 // Vue.js brand colors
 const vueGreen = '#41B883'
@@ -26,6 +28,10 @@ function resetAnimation() {
     animationValue.value = 72
   }, 1000)
 }
+
+function toggleIdleMode() {
+  idleMode.value = !idleMode.value
+}
 </script>
 
 <template>
@@ -42,9 +48,21 @@ function resetAnimation() {
       </Card>
 
       <Card class="flex flex-col items-center rounded-lg border p-4">
-        <CardTitle class="mb-4 text-center text-lg font-medium">With Value Display</CardTitle>
+        <CardTitle class="mb-4 flex w-full items-center justify-between">
+          <p class="text-lg font-medium">With Value Display</p>
+          <div class="flex items-center space-x-2">
+            <Checkbox id="idle-mode" v-model="idleMode" @change="toggleIdleMode" />
+            <Label for="idle-mode">Idle Mode</Label>
+          </div>
+        </CardTitle>
         <CardContent class="flex flex-col items-center text-center">
-          <Gauge :value="value" :size="80" :show-value="true" />
+          <Gauge
+            :value="value"
+            :size="80"
+            :show-value="true"
+            :idle-mode="idleMode"
+            :show-animation="idleMode"
+          />
           <CardDescription class="mt-4 text-sm text-gray-500">
             Shows the numerical value inside the gauge
           </CardDescription>

--- a/vue-circular-gauge/README.md
+++ b/vue-circular-gauge/README.md
@@ -8,6 +8,7 @@ A highly customizable circular gauge component for Vue.js applications. Perfect 
 - 🔄 Optional animations
 - 📏 Multiple sizes (xs, sm, md, lg, xl, 2xl)
 - 📊 Value display option
+- 🔌 Idle mode with customizable icon
 - 🚀 Lightweight (~5kb minified)
 - 🧩 TypeScript support
 - 📦 Vue 3 and Composition API support
@@ -107,6 +108,27 @@ const currentValue = ref(45)
 </template>
 ```
 
+### With Idle Mode
+
+```vue
+<template>
+  <Gauge :value="75" :idleMode="true" />
+</template>
+```
+
+### With Custom Idle Icon
+
+```vue
+<template>
+  <Gauge
+    :value="75"
+    :idleMode="true"
+    idleIcon="M10,20 L20,10 L30,20 L40,10 L50,20"
+    idleIconColor="#3b82f6"
+  />
+</template>
+```
+
 ### Custom Size
 
 ```vue
@@ -154,17 +176,20 @@ const value = ref(75)
 
 ## Props
 
-| Prop            | Type                                                                | Default       | Description                                |
-| --------------- | ------------------------------------------------------------------- | ------------- | ------------------------------------------ |
-| `value`         | `number`                                                            | `0`           | Current value of the gauge (0-100)         |
-| `size`          | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl' \| number \| string` | `'md'`        | Size of the gauge                          |
-| `gapPercent`    | `number`                                                            | `5`           | Gap percentage of the gauge                |
-| `strokeWidth`   | `number`                                                            | `10`          | Width of the gauge's stroke                |
-| `variant`       | `'ascending' \| 'descending'`                                       | `'ascending'` | Direction of the gauge progress            |
-| `showValue`     | `boolean`                                                           | `false`       | Whether to show the value inside the gauge |
-| `showAnimation` | `boolean`                                                           | `false`       | Whether to animate the gauge on mount      |
-| `primary`       | `string \| Record<number, string>`                                  | `'#10b981'`   | Primary color or color thresholds          |
-| `secondary`     | `string \| Record<number, string>`                                  | `'#e5e7eb'`   | Secondary color or color thresholds        |
+| Prop            | Type                                                                | Default                                | Description                                |
+| --------------- | ------------------------------------------------------------------- | -------------------------------------- | ------------------------------------------ |
+| `value`         | `number`                                                            | `0`                                    | Current value of the gauge (0-100)         |
+| `size`          | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl' \| number \| string` | `'md'`                                 | Size of the gauge                          |
+| `gapPercent`    | `number`                                                            | `5`                                    | Gap percentage of the gauge                |
+| `strokeWidth`   | `number`                                                            | `10`                                   | Width of the gauge's stroke                |
+| `variant`       | `'ascending' \| 'descending'`                                       | `'ascending'`                          | Direction of the gauge progress            |
+| `showValue`     | `boolean`                                                           | `false`                                | Whether to show the value inside the gauge |
+| `showAnimation` | `boolean`                                                           | `false`                                | Whether to animate the gauge on mount      |
+| `primary`       | `string \| Record<number, string>`                                  | `'#10b981'`                            | Primary color or color thresholds          |
+| `secondary`     | `string \| Record<number, string>`                                  | `'#e5e7eb'`                            | Secondary color or color thresholds        |
+| `idleMode`      | `boolean`                                                           | `false`                                | Whether to show idle icon instead of value |
+| `idleIcon`      | `string`                                                            | `'M10,20 L20,10 L30,20 L40,10 L50,20'` | SVG path for the idle icon                 |
+| `idleIconColor` | `string`                                                            | `'currentColor'`                       | Color of the idle icon                     |
 
 ## License
 

--- a/vue-circular-gauge/README.md
+++ b/vue-circular-gauge/README.md
@@ -176,20 +176,19 @@ const value = ref(75)
 
 ## Props
 
-| Prop            | Type                                                                | Default                                | Description                                |
-| --------------- | ------------------------------------------------------------------- | -------------------------------------- | ------------------------------------------ |
-| `value`         | `number`                                                            | `0`                                    | Current value of the gauge (0-100)         |
-| `size`          | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl' \| number \| string` | `'md'`                                 | Size of the gauge                          |
-| `gapPercent`    | `number`                                                            | `5`                                    | Gap percentage of the gauge                |
-| `strokeWidth`   | `number`                                                            | `10`                                   | Width of the gauge's stroke                |
-| `variant`       | `'ascending' \| 'descending'`                                       | `'ascending'`                          | Direction of the gauge progress            |
-| `showValue`     | `boolean`                                                           | `false`                                | Whether to show the value inside the gauge |
-| `showAnimation` | `boolean`                                                           | `false`                                | Whether to animate the gauge on mount      |
-| `primary`       | `string \| Record<number, string>`                                  | `'#10b981'`                            | Primary color or color thresholds          |
-| `secondary`     | `string \| Record<number, string>`                                  | `'#e5e7eb'`                            | Secondary color or color thresholds        |
-| `idleMode`      | `boolean`                                                           | `false`                                | Whether to show idle icon instead of value |
-| `idleIcon`      | `string`                                                            | `'M10,20 L20,10 L30,20 L40,10 L50,20'` | SVG path for the idle icon                 |
-| `idleIconColor` | `string`                                                            | `'currentColor'`                       | Color of the idle icon                     |
+| Prop            | Type                                                                | Default          | Description                                |
+| --------------- | ------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
+| `value`         | `number`                                                            | `0`              | Current value of the gauge (0-100)         |
+| `size`          | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl' \| number \| string` | `'md'`           | Size of the gauge                          |
+| `gapPercent`    | `number`                                                            | `5`              | Gap percentage of the gauge                |
+| `strokeWidth`   | `number`                                                            | `10`             | Width of the gauge's stroke                |
+| `variant`       | `'ascending' \| 'descending'`                                       | `'ascending'`    | Direction of the gauge progress            |
+| `showValue`     | `boolean`                                                           | `false`          | Whether to show the value inside the gauge |
+| `showAnimation` | `boolean`                                                           | `false`          | Whether to animate the gauge on mount      |
+| `primary`       | `string \| Record<number, string>`                                  | `'#10b981'`      | Primary color or color thresholds          |
+| `secondary`     | `string \| Record<number, string>`                                  | `'#e5e7eb'`      | Secondary color or color thresholds        |
+| `idleMode`      | `boolean`                                                           | `false`          | Whether to show idle icon instead of value |
+| `idleIconColor` | `string`                                                            | `'currentColor'` | Color of the idle icon                     |
 
 ## License
 

--- a/vue-circular-gauge/package.json
+++ b/vue-circular-gauge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-circular-gauge",
-  "version": "1.3.0",
+  "version": "2.0.1",
   "description": "Circular gauge component for Vue.js with customizable colors, animations, and thresholds",
   "author": "Gökhan Öztürk",
   "license": "MIT",

--- a/vue-circular-gauge/src/components/Gauge.vue
+++ b/vue-circular-gauge/src/components/Gauge.vue
@@ -242,23 +242,31 @@ const iconYOffset = computed(
     <!-- Idle mode icon -->
     <motion.path
       v-if="idleMode"
-      fill-rule="evenodd"
-      clip-rule="evenodd"
-      d="M5.51324 3.62367L3.76375 8.34731C3.61845 8.7396 3.24433 8.99999 2.826 8.99999H0.75H0V7.49999H0.75H2.47799L4.56666 1.86057C4.88684 0.996097 6.10683 0.988493 6.43776 1.84891L10.5137 12.4463L12.2408 8.1286C12.3926 7.74894 12.7604 7.49999 13.1693 7.49999H15.25H16V8.99999H15.25H13.5078L11.433 14.1868C11.0954 15.031 9.8976 15.023 9.57122 14.1744L5.51324 3.62367Z"
-      :fill="idleIconColor"
-      :transform="`translate(${iconXOffset}, ${iconYOffset}) scale(${iconScale})`"
+      fill="none"
       :stroke="idleIconColor"
+      :stroke-width="strokeWidth / 3"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      :transform="`translate(${centerPosition - 12}, ${centerPosition - 12})`"
+      d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"
+      :initial="{
+        opacity: 1,
+        pathLength: 1,
+        pathOffset: 0,
+      }"
       :animate="{
-        pathLength: [0, 1],
         opacity: [0, 1],
+        pathLength: [0, 1],
+        pathOffset: [1, 0],
       }"
       :transition="{
-        duration: 0.5,
-        ease: 'easeInOut',
+        duration: 0.6,
+        ease: 'linear',
       }"
       :exit="{
-        pathLength: [1, 0],
-        opacity: [1, 0],
+        opacity: 0,
+        pathLength: 1,
+        pathOffset: 0,
       }"
     />
 

--- a/vue-circular-gauge/src/components/Gauge.vue
+++ b/vue-circular-gauge/src/components/Gauge.vue
@@ -22,6 +22,7 @@ import {
 } from '../utils'
 
 import type { GaugeProps, Size } from '@/types'
+import { motion } from 'motion-v'
 
 /**
  * Renders a circular gauge using SVG. Allows configuration of colors, stroke, and animations.
@@ -36,7 +37,6 @@ import type { GaugeProps, Size } from '@/types'
  * @param primary - Primary color or set of colors for the gauge, with optional threshold values to determine color changes.
  * @param secondary - Secondary color or set of colors for the gauge, similar to `primary`.
  * @param idleMode - Shows a pulse icon in the center instead of value. Defaults to false.
- * @param idleIcon - Custom SVG path for the idle icon. Defaults to a pulse/heartbeat icon.
  * @param idleIconColor - Color of the idle icon. Defaults to currentColor.
  * @param props - Configuration and properties for the svg.
  */
@@ -51,8 +51,7 @@ const {
   secondary = '#e5e7eb',
   value = 0,
   idleMode = false,
-  idleIcon = 'M10,20 L20,10 L30,20 L40,10 L50,20',
-  idleIconColor = 'currentColor',
+  idleIconColor = 'hsl(0, 0%, 40%)',
 } = defineProps<GaugeProps>()
 
 const circleSize = 100 // px
@@ -187,11 +186,22 @@ const fontSize = computed(() => {
 // Calculate icon size based on gauge size
 const iconSize = computed(() => {
   const gaugeSize = sizeConfig[size as Size]?.size || 50
-  return Math.max(Math.floor(gaugeSize / 2), 24)
+  return Math.max(Math.floor(gaugeSize / 1.2), 40)
 })
 
-// Center position for icon/text
+// Original SVG viewBox dimensions
+const originalIconWidth = 16 // SVG path width
+const originalIconHeight = 16 // SVG path height
+
+// Center position calculations
 const centerPosition = computed(() => circleSize / 2)
+const iconScale = computed(() => iconSize.value / 16)
+
+// Icon position adjustments
+const iconXOffset = computed(() => centerPosition.value - (originalIconWidth * iconScale.value) / 2)
+const iconYOffset = computed(
+  () => centerPosition.value - (originalIconHeight * iconScale.value) / 2,
+)
 </script>
 
 <template>
@@ -230,15 +240,26 @@ const centerPosition = computed(() => circleSize / 2)
     />
 
     <!-- Idle mode icon -->
-    <path
+    <motion.path
       v-if="idleMode"
-      :d="idleIcon"
-      :fill="'none'"
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M5.51324 3.62367L3.76375 8.34731C3.61845 8.7396 3.24433 8.99999 2.826 8.99999H0.75H0V7.49999H0.75H2.47799L4.56666 1.86057C4.88684 0.996097 6.10683 0.988493 6.43776 1.84891L10.5137 12.4463L12.2408 8.1286C12.3926 7.74894 12.7604 7.49999 13.1693 7.49999H15.25H16V8.99999H15.25H13.5078L11.433 14.1868C11.0954 15.031 9.8976 15.023 9.57122 14.1744L5.51324 3.62367Z"
+      :fill="idleIconColor"
+      :transform="`translate(${iconXOffset}, ${iconYOffset}) scale(${iconScale})`"
       :stroke="idleIconColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      :transform="`translate(${centerPosition - iconSize / 2}, ${centerPosition - iconSize / 4}) scale(${iconSize / 50})`"
+      :animate="{
+        pathLength: [0, 1],
+        opacity: [0, 1],
+      }"
+      :transition="{
+        duration: 0.5,
+        ease: 'easeInOut',
+      }"
+      :exit="{
+        pathLength: [1, 0],
+        opacity: [1, 0],
+      }"
     />
 
     <!-- Value text -->

--- a/vue-circular-gauge/src/components/Gauge.vue
+++ b/vue-circular-gauge/src/components/Gauge.vue
@@ -151,7 +151,9 @@ const secondaryTransform = computed(() =>
   ),
 )
 
-const primaryStroke = computed(() => calculatePrimaryStroke(primary, effectiveStrokePercent.value))
+const primaryStroke = computed(() =>
+  calculatePrimaryStroke(idleMode ? secondary : primary, effectiveStrokePercent.value),
+)
 const secondaryStroke = computed(() =>
   idleMode
     ? primaryStroke.value

--- a/vue-circular-gauge/src/types.ts
+++ b/vue-circular-gauge/src/types.ts
@@ -12,4 +12,7 @@ export interface GaugeProps extends /* @vue-ignore */ SVGAttributes {
   showAnimation?: boolean
   primary?: string | { [key: number]: string }
   secondary?: string | { [key: number]: string }
+  idleMode?: boolean
+  idleIcon?: string
+  idleIconColor?: string
 }

--- a/vue-circular-gauge/src/types.ts
+++ b/vue-circular-gauge/src/types.ts
@@ -13,6 +13,5 @@ export interface GaugeProps extends /* @vue-ignore */ SVGAttributes {
   primary?: string | { [key: number]: string }
   secondary?: string | { [key: number]: string }
   idleMode?: boolean
-  idleIcon?: string
   idleIconColor?: string
 }


### PR DESCRIPTION
- Introduced `idleMode` prop to display a pulse icon instead of the value.
- Added `idleIcon` and `idleIconColor` props for customization of the idle icon.
- Updated Playground.vue to include idle mode configuration.
- Enhanced README.md with examples for idle mode and custom idle icon.
